### PR TITLE
Update from bindgen v0.24.0 to v0.53.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT/Apache-2.0"
 links = "PCANBasic"
 
 [build-dependencies]
-bindgen = "0.24.0"
+bindgen = "0.53.2"

--- a/build.rs
+++ b/build.rs
@@ -12,10 +12,6 @@ fn main() {
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
-        // Do not generate unstable Rust code that
-        // requires a nightly rustc and enabling
-        // unstable features.
-        .no_unstable_rust()
         // The input header we would like to generate
         // bindings for.
         .header("PCANBasic.h")


### PR DESCRIPTION
`bindgen-0.24.0` uses `syntext_syntax_0.58.1`, which is not compatible with latest rust compiler.

Updating to `bindgen-0.53.2` the [function](https://docs.rs/bindgen/0.24.0/bindgen/struct.Builder.html#method.no_unstable_rust) `no_unstable_rust()` for struct `Builder` is now deprecated and was replaced with [function](https://docs.rs/bindgen/0.53.2/src/bindgen/lib.rs.html#1307-1314) `pub fn unstable_rust(self, doit: bool) -> Self` which is also deprecated and is being replaced with [function](https://docs.rs/bindgen/0.53.2/src/bindgen/lib.rs.html#697-700) `pub fn rust_target(mut self, rust_target: RustTarget) -> Self`

`rust_target()` is defaulted to latest stable Rust version per the [documentation](https://docs.rs/bindgen/0.53.2/bindgen/struct.Builder.html#method.rust_target)

Note: updating bindgen does cause a warning on windows when using the pre-built llvm library because `llvm-config` is not included in library. Only included if complied from source 

```
Compiling pcan-basic-sys v0.2.0 
warning: couldn't execute `llvm-config --prefix` (error: The system cannot find the file specified. (os error 2))
warning: set the LLVM_CONFIG_PATH environment variable to the full path to a valid `llvm-config` executable (including the executable itself)
Finished dev [unoptimized + debuginfo] target(s) in 51.07s
```
